### PR TITLE
fixing Kepler's law in sensitivity.py

### DIFF
--- a/sensitivity/sensitivity.py
+++ b/sensitivity/sensitivity.py
@@ -152,7 +152,7 @@ if plot['Kepler_planets']:
     print(keplerplanets.shape)
     print(kepdots.shape)
     def ksemimajor(x):
-        return ((x[:]['koi_period']/365.25)**2/x[:]['koi_smass'])**(1.0/3.0)
+        return ((x[:]['koi_period']/365.25)**2*x[:]['koi_smass'])**(1.0/3.0)
     def massradius(x):
         ret = x[:]['koi_prad']**2.06 #Use the Lissauer M-R relation
         return ret


### PR DESCRIPTION
there was a typo on line 155 in computing the semi-major axis for the Kepler KOIs, was (P^2/M)^1/3 and should be (P^2 * M)^1/3